### PR TITLE
Update pyproject.toml, add build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "monzopy"
 version = "1.3.0"


### PR DESCRIPTION
otherwise:

```
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 0.43, 0.35, 0.35
 * Package:    dev-python/monzopy-1.2.0:0
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   jake_martin_@outlook.com
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_12
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking monzopy-1.2.0.tar.gz to /var/tmp/portage/dev-python/monzopy-1.2.0/work
>>> Source unpacked in /var/tmp/portage/dev-python/monzopy-1.2.0/work
>>> Preparing source in /var/tmp/portage/dev-python/monzopy-1.2.0/work/monzopy-1.2.0 ...
 * Build system packages:
 *   dev-python/gpep517            : 16
 *   dev-python/installer          : 0.7.0
 *   dev-python/poetry-core        : 1.9.0
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/monzopy-1.2.0/work/monzopy-1.2.0 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/monzopy-1.2.0/work/monzopy-1.2.0 ...
 * python3_12: running distutils-r1_run_phase distutils-r1_python_compile
 * ERROR: dev-python/monzopy-1.2.0::HomeAssistantRepository failed (compile phase):
 *   Unable to obtain build-backend from pyproject.toml
 *
 * Call stack:
 *     ebuild.sh, line  136:  Called src_compile
 *   environment, line 3997:  Called distutils-r1_src_compile
 *   environment, line 1934:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_compile'
 *   environment, line  749:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_compile'
 *   environment, line 3621:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_compile'
 *   environment, line 3119:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_compile'
 *   environment, line 3117:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_compile'
 *   environment, line 1239:  Called distutils-r1_run_phase 'distutils-r1_python_compile'
 *   environment, line 1916:  Called distutils-r1_python_compile
 *   environment, line 1734:  Called distutils_pep517_install '/var/tmp/portage/dev-python/monzopy-1.2.0/work/monzopy-1.2.0-python3_12/install'
```